### PR TITLE
Add helper script for deploying at 34SP

### DIFF
--- a/bin/deploy-34sp
+++ b/bin/deploy-34sp
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+cd "$(dirname "$0")/.."
+cp -r ./fixmyblock-theme /var/www/vhosts/fixmyblock.org/httpdocs/wp-content/themes
+


### PR DESCRIPTION
As the actual theme is in a subdirectory, the easiest way to deploy this at 34SP may be to clone elsewhere and copy across the theme directory. This script can be run to do this on the 34SP server.

